### PR TITLE
I added a `onBeforeInit` and `onComplete` callback

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,10 +55,10 @@ app.use(vueKeycloak, {
 
 | Object       | Type                                          | Required | Description                                |
 | ------------ | --------------------------------------------- | -------- | ------------------------------------------ |
-| config        | [`KeycloakConfig`][Config]                      | Yes      | Keycloak configuration.                     |
+| config       | [`KeycloakConfig`][Config]                    | Yes      | Keycloak configuration.                    |
 | initOptions  | [`KeycloakInitOptions`][InitOptions]          | No       | Keycloak init options.                     |
 | onBeforeInit | <pre>(keycloak: Keycloak) => void</pre>       | No       | Callback after keycloak instance creation. |
-| onComplete   | <pre>(keycloak: Keycloak) => void</pre>       | No       | Callback after first initialization.        |
+| onComplete   | <pre>(keycloak: Keycloak) => void</pre>       | No       | Callback after first initialization.       |
 
 #### `initOptions` Default Value
 
@@ -91,12 +91,20 @@ app.use(vueKeycloak, async () => {
 ```
 
 ### `onBeforeInit` callback
-
 This callback can be used to interact with the keycloak instance like registering [`callbacks`][Callbacks] on the keycloak instance.
 
 ### `onComplete` callback
-
 This callback can be used to continue after the first initialization.
+
+```typescript
+...
+  onComplete() {
+    app.use(router);
+
+    app.mount('#app');
+  }
+...
+```
 
 ## Use Token
 

--- a/README.md
+++ b/README.md
@@ -53,10 +53,12 @@ app.use(vueKeycloak, {
 
 ### Configuration
 
-| Object      | Type                                          | Required | Description                              |
-| ----------- | --------------------------------------------- | -------- | ---------------------------------------- |
-| config      | [`KeycloakConfig`][Config]                    | Yes      | Keycloak configuration.                  |
-| initOptions | [`KeycloakInitOptions`][InitOptions]          | No       | Keycloak init options.                   |
+| Object       | Type                                          | Required | Description                                |
+| ------------ | --------------------------------------------- | -------- | ------------------------------------------ |
+| config        | [`KeycloakConfig`][Config]                      | Yes      | Keycloak configuration.                     |
+| initOptions  | [`KeycloakInitOptions`][InitOptions]          | No       | Keycloak init options.                     |
+| onBeforeInit | <pre>(keycloak: Keycloak) => void</pre>       | No       | Callback after keycloak instance creation. |
+| onComplete   | <pre>(keycloak: Keycloak) => void</pre>       | No       | Callback after first initialization.        |
 
 #### `initOptions` Default Value
 
@@ -87,6 +89,14 @@ app.use(vueKeycloak, async () => {
   }
 })
 ```
+
+### `onBeforeInit` callback
+
+This callback can be used to interact with the keycloak instance like registering [`callbacks`][Callbacks] on the keycloak instance.
+
+### `onComplete` callback
+
+This callback can be used to continue after the first initialization.
 
 ## Use Token
 
@@ -163,6 +173,7 @@ const {
   hasResourceRoles,
 } = useKeycloak()
 ```
+
 #### Reactive State
 
 | State           | Type                                                   | Description                                                         |
@@ -198,3 +209,4 @@ Apache-2.0 Licensed | Copyright © 2021-present Gery Hirschfeld & Contributors
 [InitOptions]: https://github.com/keycloak/keycloak/blob/main/js/libs/keycloak-js/dist/keycloak.d.ts#L55-L215
 [TokenParsed]: https://github.com/keycloak/keycloak/blob/main/js/libs/keycloak-js/dist/keycloak.d.ts#L337-L352
 [Instance]: https://github.com/keycloak/keycloak/blob/main/js/libs/keycloak-js/dist/keycloak.d.ts#L371-L650
+[Callbacks]: https://github.com/keycloak/keycloak/blob/main/js/libs/keycloak-js/dist/keycloak.d.ts#L496

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "@benny-noumena/vue-keycloak",
-  "version": "2.7.1",
+  "name": "@josempgon/vue-keycloak",
+  "version": "2.7.0",
   "description": "Keycloak plugin for Vue 3 with Composition API",
   "author": {
     "name": "Gery Hirschfeld",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "@josempgon/vue-keycloak",
-  "version": "2.7.0",
+  "name": "@benny-noumena/vue-keycloak",
+  "version": "2.7.1",
   "description": "Keycloak plugin for Vue 3 with Composition API",
   "author": {
     "name": "Gery Hirschfeld",

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -3,7 +3,7 @@ import Keycloak from 'keycloak-js'
 import type { KeycloakConfig, KeycloakInitOptions } from 'keycloak-js'
 import { defaultInitConfig } from './const'
 import { createKeycloak, initKeycloak } from './keycloak'
-import { isPromise, isFunction, isNil } from './utils'
+import { isPromise, isFunction, isNil, noop } from './utils'
 
 interface KeycloakPluginConfig {
   config: KeycloakConfig
@@ -43,8 +43,8 @@ export const vueKeycloak: Plugin = {
     app.config.globalProperties.$keycloak = _keycloak
 
     const {
-      onBeforeInit = () => {},
-      onComplete = () => {},
+      onBeforeInit = noop,
+      onComplete = noop,
     } = keycloakPluginConfig
 
     onBeforeInit(_keycloak)

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -1,4 +1,5 @@
 import { Plugin } from 'vue'
+import Keycloak from 'keycloak-js'
 import type { KeycloakConfig, KeycloakInitOptions } from 'keycloak-js'
 import { defaultInitConfig } from './const'
 import { createKeycloak, initKeycloak } from './keycloak'
@@ -7,6 +8,8 @@ import { isPromise, isFunction, isNil } from './utils'
 interface KeycloakPluginConfig {
   config: KeycloakConfig
   initOptions?: KeycloakInitOptions
+  onBeforeInit?: (keycloak: Keycloak) => void
+  onComplete?: (keycloak: Keycloak) => void
 }
 
 type KeycloakConfigFactory = () => KeycloakPluginConfig
@@ -39,6 +42,13 @@ export const vueKeycloak: Plugin = {
     const _keycloak = createKeycloak(keycloakConfig)
     app.config.globalProperties.$keycloak = _keycloak
 
+    const {
+      onBeforeInit = () => {},
+      onComplete = () => {},
+    } = keycloakPluginConfig
+
+    onBeforeInit(_keycloak)
     await initKeycloak(keycloakInitOptions)
+    onComplete(_keycloak)
   },
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -9,3 +9,5 @@ export function isFunction(fun: unknown): boolean {
 export function isNil(value: unknown): boolean {
   return value === undefined || value === null
 }
+
+export function noop() {}


### PR DESCRIPTION
Hi Jose

I was in need of a way to initialise the router only after the authentication is completed.
First I was using the `onReady` callback on the keycloak instance but then decided to do it after the initialisation as otherwise graphql for me would try to connect before it was authenticated.

Anyway.... would love to get this in or adjust it to your comments.

Best Benny