### PR TITLE
Update keycloak url in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ const app = createApp(App)
 
 app.use(vueKeycloak, {
   config: {
-    url: 'http://keycloak-server/auth',
+    url: 'http://keycloak-server',
     realm: 'my-realm',
     clientId: 'my-app',
   }
@@ -76,7 +76,7 @@ app.use(vueKeycloak, async () => {
   const authBaseUrl = await getAuthBaseUrl()
   return {
     config: {
-      url: `${authBaseUrl}/auth`,
+      url: `${authBaseUrl}`,
       realm: 'my-realm',
       clientId: 'my-app',
     },
@@ -116,7 +116,7 @@ const app = createApp(App)
 
 await vueKeycloak.install(app, {
   config: {
-    url: 'http://keycloak-server/auth',
+    url: 'http://keycloak-server',
     realm: 'my-realm',
     clientId: 'my-app',
   },


### PR DESCRIPTION
`/auth` renders a "We are sorry.. page not found" page

https://www.keycloak.org/migration/migrating-to-quarkus:
- /auth removed from the default context path
