### PR TITLE
Reject getToken() promise on undefined token

### DIFF
--- a/src/keycloak.ts
+++ b/src/keycloak.ts
@@ -11,10 +11,12 @@ async function updateToken(minValidity: number): Promise<string> {
   try {
     await $keycloak.updateToken(minValidity)
     setToken($keycloak.token, $keycloak.tokenParsed)
+    return $keycloak.token
   } catch (err) {
-    hasFailed(true, isNil(err) ? new Error('Failed to refresh the access token') : err)
+    const rejectionReason = isNil(err) ? new Error('Failed to refresh the access token') : err
+    hasFailed(true, rejectionReason)
+    throw rejectionReason
   }
-  return $keycloak.token
 }
 
 export async function getToken(minValidity: number = 10): Promise<string> {


### PR DESCRIPTION
As promised the pull request for #21 

I could not get `jest` to work. First it failed with 

```plain
$ npm run test

> @josempgon/vue-keycloak@3.3.0 test
> jest

● Validation Error:

  Module ts-jest in the transform option was not found.
         <rootDir> is: /home/.../vue-keycloak

  Configuration Documentation:
  https://jestjs.io/docs/configuration
```

with a fixed `jest.config.js` (`transform: {    '^.+\\.(ts|tsx)$': '<rootDir>/node_modules/ts-jest', },`):

```plain
$ npm run test

> @josempgon/vue-keycloak@3.3.0 test
> jest

 FAIL  src/utils.test.ts
  ● Test suite failed to run

    Cannot find module 'source-map' from 'node_modules/source-map-support/source-map-support.js'

      at Resolver._throwModNotFoundError (node_modules/jest-resolve/build/index.js:868:11)
      at Object.<anonymous> (node_modules/source-map-support/source-map-support.js:1:25)

 FAIL  src/state.test.ts
  ● Test suite failed to run

    Cannot find module 'source-map' from 'node_modules/source-map-support/source-map-support.js'

      at Resolver._throwModNotFoundError (node_modules/jest-resolve/build/index.js:868:11)
      at Object.<anonymous> (node_modules/source-map-support/source-map-support.js:1:25)

 FAIL  src/plugin.test.ts
  ● Test suite failed to run

    Cannot find module 'source-map' from 'node_modules/source-map-support/source-map-support.js'

      at Resolver._throwModNotFoundError (node_modules/jest-resolve/build/index.js:868:11)
      at Object.<anonymous> (node_modules/source-map-support/source-map-support.js:1:25)

 FAIL  src/const.test.ts
  ● Test suite failed to run

    Cannot find module 'source-map' from 'node_modules/source-map-support/source-map-support.js'

      at Resolver._throwModNotFoundError (node_modules/jest-resolve/build/index.js:868:11)
      at Object.<anonymous> (node_modules/source-map-support/source-map-support.js:1:25)

 FAIL  src/composable.test.ts
  ● Test suite failed to run

    Cannot find module 'source-map' from 'node_modules/source-map-support/source-map-support.js'

      at Resolver._throwModNotFoundError (node_modules/jest-resolve/build/index.js:868:11)
      at Object.<anonymous> (node_modules/source-map-support/source-map-support.js:1:25)

 FAIL  src/keycloak.test.ts
  ● Test suite failed to run

    Cannot find module 'source-map' from 'node_modules/source-map-support/source-map-support.js'

      at Resolver._throwModNotFoundError (node_modules/jest-resolve/build/index.js:868:11)
      at Object.<anonymous> (node_modules/source-map-support/source-map-support.js:1:25)

Test Suites: 6 failed, 6 total
Tests:       0 total
Snapshots:   0 total
Time:        2.092 s
Ran all test suites.
```



